### PR TITLE
[FIX] Create record

### DIFF
--- a/src/modules/record/services/create-record.service.ts
+++ b/src/modules/record/services/create-record.service.ts
@@ -35,6 +35,14 @@ export class CreateRecordService {
       { appointmentId },
     );
 
+    if (!appointmentResponse.appointments.length) {
+      throw new AppError(
+        'record-module.createRecordService',
+        400,
+        `invalid 'appointmentId'`,
+      );
+    }
+
     const { clientName, appointmentDate, appointmentTime } =
       appointmentResponse.appointments[0];
 

--- a/src/modules/record/test/record.service.spec.ts
+++ b/src/modules/record/test/record.service.spec.ts
@@ -123,6 +123,24 @@ describe('RecordServices', () => {
       }
     });
 
+    it('should throw an AppError if an appointment is not found', async () => {
+      jest
+        .spyOn(schedulerRepository, 'getApptByFilter')
+        .mockResolvedValueOnce({ appointments: [] });
+
+      try {
+        await createRecordService.execute(
+          mockProfessionalId,
+          mockAppointmentId,
+          mockCreateRecord,
+        );
+      } catch (error) {
+        expect(error).toBeInstanceOf(AppError);
+        expect(error.code).toBe(400);
+        expect(error.message).toBe(`invalid 'appointmentId'`);
+      }
+    });
+
     it('should throw an AppError if creating a record before the appointment date', async () => {
       jest
         .spyOn(schedulerRepository, 'getApptByFilter')

--- a/swagger.json
+++ b/swagger.json
@@ -1344,13 +1344,30 @@
                 "schema": {
                   "$ref": "#/components/schemas/Error"
                 },
-                "example": {
-                  "error": {
-                    "message": "missing query parameter [professionalId, appointmentId]",
-                    "code": "record-module.createRecordService",
-                    "status": true
+
+                "examples": {
+                  "example1": {
+                    "summary": "Missing parameter",
+                    "value": {
+                      "error": {
+                        "message": "missing query parameter [professionalId, appointmentId]",
+                        "code": "record-module.createRecordService",
+                        "status": true
+                      },
+                      "data": {}
+                    }
                   },
-                  "data": {}
+                  "example2": {
+                    "summary": "Invalid parameter",
+                    "value": {
+                      "error": {
+                        "message": "invalid 'appointmentId'",
+                        "code": "record-module.createRecordService",
+                        "status": true
+                      },
+                      "data": {}
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
Add validation when creating client record.

If an appointment is not found with the provided `appointmentId`, throws an app error.

-Unit test;
-Swagger doc.